### PR TITLE
Fix uv_close assertion on VimLeavePre

### DIFF
--- a/lua/chameleon/init.lua
+++ b/lua/chameleon/init.lua
@@ -77,6 +77,8 @@ local setup_autocmds = function()
 		callback = function()
 			if M.original_color ~= nil then
 				change_background(M.original_color, true)
+				-- https://github.com/neovim/neovim/issues/21856
+				vim.cmd[[sleep 10m]]
 			end
 		end,
 		group = autogroup("BackgroundRestore", { clear = true }),


### PR DESCRIPTION
According to erw7, loop_poll_event() is no longer executed which cause an assertion on VimLeavePre. A simple workaround for now is to sleep (detach didn't work in my tests).

https://github.com/neovim/neovim/issues/21856