### PR TITLE
Set and restore kitty background on SIGTSTP and SIGCONT

### DIFF
--- a/lua/chameleon/init.lua
+++ b/lua/chameleon/init.lua
@@ -53,7 +53,7 @@ local setup_autocmds = function()
 	local autogroup = api.nvim_create_augroup
 	local bg_change = autogroup("BackgroundChange", { clear = true })
 
-	autocmd("ColorScheme", {
+	autocmd({"ColorScheme", "VimResume"}, {
 		pattern = "*",
 		callback = function()
 			local color = get_color("Normal", "bg")
@@ -73,7 +73,7 @@ local setup_autocmds = function()
 		group = bg_change,
 	})
 
-	autocmd("VimLeavePre", {
+	autocmd({"VimLeavePre", "VimSuspend"}, {
 		callback = function()
 			if M.original_color ~= nil then
 				change_background(M.original_color, true)


### PR DESCRIPTION
### Before:

![Screenshot from 2024-01-24 11-04-37](https://github.com/shaun-mathew/Chameleon.nvim/assets/91024200/84f78212-8b0f-4719-93d2-d31a36da9633)
![Screenshot from 2024-01-24 11-04-42](https://github.com/shaun-mathew/Chameleon.nvim/assets/91024200/3fe18599-d1fe-429d-a4e6-54cc51ab4294)

### After:

![Screenshot from 2024-01-24 11-04-57](https://github.com/shaun-mathew/Chameleon.nvim/assets/91024200/7bcaf6f2-4c44-4c60-bba9-103bcc8bc52d)
![Screenshot from 2024-01-24 11-05-03](https://github.com/shaun-mathew/Chameleon.nvim/assets/91024200/5f055308-9e60-47b3-8bcf-89a09f3f361f)
