### PR TITLE
Added tab bar sync

### DIFF
--- a/lua/chameleon/init.lua
+++ b/lua/chameleon/init.lua
@@ -116,6 +116,7 @@ local setup_autocmds = function()
       local fg_color = string.format("#%06X", vim.api.nvim_get_hl(0, { name = "Normal" }).fg)
 
 
+
       change_background(bg_color)
       change_foreground(fg_color)
     end,
@@ -158,4 +159,6 @@ M.setup = function()
   end
 end
 
+require("chameleon.register")
+require("chameleon.kitty")
 return M

--- a/lua/chameleon/init.lua
+++ b/lua/chameleon/init.lua
@@ -1,90 +1,161 @@
 local M = {}
 local fn = vim.fn
 local api = vim.api
-M.original_color = nil
+M.original_bg_color = nil
+M.inactive_tab_foreground = nil
+M.active_tab_background = nil
 
-local get_kitty_background = function()
-	if M.original_color == nil then
-		fn.jobstart({ "kitty", "@", "get-colors" }, {
-			on_stdout = function(_, d, _)
-				for _, result in ipairs(d) do
-					if string.match(result, "^background") then
-						local color = vim.split(result, "%s+")[2]
-						M.original_color = color
-						break
-					end
-				end
-			end,
-			on_stderr = function(_, d, _)
-				if #d > 1 then
-					api.nvim_err_writeln(
-						"Chameleon.nvim: Error getting background. Make sure kitty remote control is turned on."
-					)
-				end
-			end,
-		})
-	end
+local function executeKittyCmd(cmd)
+  fn.jobstart(cmd, {
+    on_stderr = function(_, d, _)
+      if #d > 1 then
+        vim.notify(
+          "Chameleon.nvim: Error changing background. Make sure kitty remote control is turned on.",
+          vim.log.levels.WARN
+        )
+      end
+    end,
+  })
+end
+
+local get_kitty_original_colors = function()
+  if M.original_bg_color == nil then
+    fn.jobstart({ "kitty", "@", "get-colors" }, {
+      on_stdout = function(_, d, _)
+        for _, result in ipairs(d) do
+          if string.match(result, "^background") then
+            local color = vim.split(result, "%s+")[2]
+            M.original_bg_color = color
+          elseif string.match(result, "^inactive_tab_foreground") then
+            local color = vim.split(result, "%s+")[2]
+            M.inactive_tab_foreground = color
+          elseif string.match(result, "^active_tab_background") then
+            local color = vim.split(result, "%s+")[2]
+            M.active_tab_background = color
+          end
+        end
+      end,
+      on_stderr = function(_, d, _)
+        if #d > 1 then
+          vim.notify(
+            "Chameleon.nvim: Error getting background. Make sure kitty remote control is turned on.",
+            vim.log.levels.WARN
+          )
+        end
+      end,
+    })
+  end
 end
 
 local change_background = function(color, sync)
-	local arg = 'background="' .. color .. '"'
-	local command = "kitty @ set-colors " .. arg
-	if not sync then
-		fn.jobstart(command, {
-			on_stderr = function(_, d, _)
-				if #d > 1 then
-					api.nvim_err_writeln(
-						"Chameleon.nvim: Error changing background. Make sure kitty remote control is turned on."
-					)
-				end
-			end,
-		})
-	else
-		fn.system(command)
-	end
+  local arg = 'background="' .. color .. '"'
+  local command = "kitty @ set-colors --match=recent:0 " .. arg
+  if not sync then
+    fn.jobstart(command, {
+      on_stderr = function(_, d, _)
+        if #d > 1 then
+          vim.notify(
+            "Chameleon.nvim: Error changing background. Make sure kitty remote control is turned on.",
+            vim.log.levels.WARN
+          )
+        end
+      end,
+    })
+  else
+    fn.system(command)
+  end
 end
 
+local change_foreground = function(color, sync, opts)
+  if not opts then
+    opts = { inactive_tab_foreground = true, active_tab_background = true }
+  end
+
+  local set_inactive_fg = 'inactive_tab_foreground="' .. color .. '"'
+  local set_active_bg = 'active_tab_background="' .. color .. '"'
+  local command = "kitty @ set-colors --match=recent:0"
+
+  if opts.inactive_tab_foreground then
+    command = command .. " " .. set_inactive_fg
+  end
+  if opts.active_tab_background then
+    command = command .. " " .. set_active_bg
+  end
+
+  if not sync then
+    executeKittyCmd(command)
+  else
+    fn.system(command)
+  end
+end
+
+local function restore_original_colors()
+  if M.original_bg_color ~= nil then
+    change_background(M.original_bg_color, true)
+  end
+
+  if M.inactive_tab_foreground ~= nil then
+    change_foreground(M.inactive_tab_foreground, true, { inactive_tab_foreground = true })
+  end
+
+  if M.active_tab_background ~= nil then
+    change_foreground(M.active_tab_background, true, { active_tab_background = true })
+  end
+end
+
+
 local setup_autocmds = function()
-	local autocmd = api.nvim_create_autocmd
-	local autogroup = api.nvim_create_augroup
-	local bg_change = autogroup("BackgroundChange", { clear = true })
+  local autocmd = api.nvim_create_autocmd
+  local autogroup = api.nvim_create_augroup
+  local bg_change = autogroup("BackgroundChange", { clear = true })
 
-	autocmd({"ColorScheme", "VimResume"}, {
-		pattern = "*",
-		callback = function()
-			local color = string.format("#%06X", vim.api.nvim_get_hl(0, {name = "Normal"}).bg)
-			change_background(color)
-		end,
-		group = bg_change,
-	})
+  autocmd({ "ColorScheme", "VimResume", "VimEnter" }, {
+    pattern = "*",
+    callback = function()
+      local bg_color = string.format("#%06X", vim.api.nvim_get_hl(0, { name = "Normal" }).bg)
+      local fg_color = string.format("#%06X", vim.api.nvim_get_hl(0, { name = "Normal" }).fg)
 
-	autocmd("User", {
-		pattern = "NvChadThemeReload",
-		callback = function()
-			local color = string.format("#%06X", vim.api.nvim_get_hl(0, {name = "Normal"}).bg)
-			change_background(color)
-			
-		end,
-		group = bg_change,
-	})
 
-	autocmd({"VimLeavePre", "VimSuspend"}, {
-		callback = function()
-			if M.original_color ~= nil then
-				change_background(M.original_color, true)
-				-- Looks like it was silently fixed in NVIM 0.10. At least, I can't reproduce it anymore,
-				-- so for now disable it and see if anyone reports it again.
-				-- https://github.com/neovim/neovim/issues/21856
-				-- vim.cmd[[sleep 10m]]
-			end
-		end,
-		group = autogroup("BackgroundRestore", { clear = true }),
-	})
+      change_background(bg_color)
+      change_foreground(fg_color)
+    end,
+    group = bg_change,
+  })
+
+  autocmd("User", {
+    pattern = "NvChadThemeReload",
+    callback = function()
+      local bg_color = string.format("#%06X", vim.api.nvim_get_hl(0, { name = "Normal" }).bg)
+      local fg_color = string.format("#%06X", vim.api.nvim_get_hl(0, { name = "Normal" }).fg)
+
+      change_background(bg_color)
+      change_foreground(fg_color)
+    end,
+    group = bg_change,
+  })
+
+  autocmd({ "VimLeavePre", "VimSuspend" }, {
+    callback = function()
+      restore_original_colors()
+      -- Looks like it was silently fixed in NVIM 0.10. At least, I can't reproduce it anymore,
+      -- so for now disable it and see if anyone reports it again.
+      -- https://github.com/neovim/neovim/issues/21856
+      -- vim.cmd[[sleep 10m]]
+    end,
+    group = autogroup("BackgroundRestore", { clear = true }),
+  })
 end
 
 M.setup = function()
-	get_kitty_background()
-	setup_autocmds()
+  if (os.getenv("KITTY_PID") ~= nil) then
+    get_kitty_original_colors()
+    setup_autocmds()
+  else
+    vim.notify(
+      "Chameleon.nvim: you are not on a kitty terminal, background won't be changed",
+      vim.log.levels.WARN
+    )
+  end
 end
 
 return M

--- a/lua/chameleon/kitty.lua
+++ b/lua/chameleon/kitty.lua
@@ -1,0 +1,40 @@
+function execute_kitty_cmd(cmd, success, fail)
+  vim.system(cmd, {},
+    function(rv)
+      -- print(vim.inspect(rv))
+
+      if rv.code == 0 then
+        if success then
+          success(rv.stdout)
+        end
+      else
+        if fail then
+          fail(rv)
+        end
+      end
+    end)
+end
+
+function get_current_tab_windows()
+  local t = { "kitty", "@", "ls", "--match-tab=recent:0" }
+
+  function on_success(stdout)
+    local json = vim.json.decode(stdout)
+    local current_tab_id = json[1].tabs[1].id
+    local windows = {}
+
+    for _, window in ipairs(json[1].tabs[1].windows) do
+      table.insert(windows, window.id)
+    end
+
+    -- print("povco dio")
+    print(vim.inspect({ [current_tab_id] = windows }))
+  end
+
+  function on_fail(rv)
+    print("ERROR")
+    print(vim.inspect(rv))
+  end
+
+  execute_kitty_cmd(t, on_success, on_fail)
+end

--- a/lua/chameleon/register.lua
+++ b/lua/chameleon/register.lua
@@ -1,0 +1,35 @@
+local dir = vim.fn.stdpath("cache") .. "/prova.json"
+
+function write_cache()
+  local json_decoded = read_json()
+  json_decoded["new_id"] = "42"
+end
+
+function test()
+  local json_decoded = read_json()
+  json_decoded["new_id"] = "42"
+  write_json(json_decoded)
+end
+
+function read_json()
+  local json = vim.fn.readfile(dir)        -- Make sure to use absolute path
+  local content = table.concat(json, "\n") -- Convert table to string
+  local json_decoded = vim.json.decode(content)
+  return json_decoded
+end
+
+function write_json(table)
+  local json_encoded = vim.json.encode(table, { indent = 1 })
+  vim.fn.writefile({ json_encoded }, dir)
+end
+
+-- saves the current nvim instance as
+-- kitty_window_id = "path to socket"
+function register()
+  print(dir)
+
+  local json = read_json()
+end
+
+function unregister()
+end


### PR DESCRIPTION
- Resolved deprecation warnings
- Background color is now changed only for the tab in which nvim is running
- Implemented tab color synchronization with the theme

Note: To ensure the tab bar background syncs correctly, you’ll need to use a custom tab bar in Kitty. This isn't a trivial task to set up, but you can use [mine](https://github.com/mattia-marini/kitty-config) as an example (its an utter mess and tested only on macOS).